### PR TITLE
Fix/replay parse file v7

### DIFF
--- a/src/structs.ts
+++ b/src/structs.ts
@@ -138,3 +138,17 @@ export interface PlayerPositions {
     [time: number]: PlayerPosition;
   },
 }
+
+export enum FLocalFileReplayCustomVersion {
+  BeforeCustomVersionWasAdded = 0,
+
+  FixedSizeFriendlyName,
+  CompressionSupport,
+  RecordingTimestamp,
+  StreamChunkTimes,
+  FriendlyNameCharEncoding,
+  EncryptionSupport,
+
+  VersionPlusOne,
+  LatestVersion = VersionPlusOne - 1,
+}

--- a/src/structs.ts
+++ b/src/structs.ts
@@ -148,6 +148,7 @@ export enum FLocalFileReplayCustomVersion {
   StreamChunkTimes,
   FriendlyNameCharEncoding,
   EncryptionSupport,
+  CustomVersions,
 
   VersionPlusOne,
   LatestVersion = VersionPlusOne - 1,

--- a/test/results/client-33.11.json
+++ b/test/results/client-33.11.json
@@ -1,0 +1,12506 @@
+{
+  "meta": {
+    "magic": 480436863,
+    "fileVersion": 7,
+    "lengthInMs": 1,
+    "networkVersion": 2510614590,
+    "changelist": 2114669028,
+    "name": "Rediffusion non sauvegardée",
+    "isLive": false,
+    "timestamp": "2024-12-21T20:41:04.302Z",
+    "isCompressed": true
+  },
+  "header": {
+    "magic": 754295101,
+    "networkVersion": 19,
+    "networkChecksum": 4,
+    "engineNetworkVersion": 1653693603,
+    "gameNetworkProtocol": 479087607,
+    "id": "c7120ea3f79d21c824000000240d40cc",
+    "version": {
+      "branch": "++Fortnite+Release-33.11",
+      "major": 33,
+      "minor": 11,
+      "changelist": 3223821305,
+      "patch": 41603
+    },
+    "fileVersionUE4": 522,
+    "fileVersionUE5": 1013,
+    "packageVersionLicenseeUe": 0,
+    "levelNamesAndTimes": {
+      "/Game/Athena/Maps/Athena_Empty": 0
+    },
+    "flags": 171,
+    "gameSpecificData": [
+      "SubGame=Athena"
+    ]
+  },
+  "matchStats": {
+    "accuracy": 0.31192660331726074,
+    "assists": 3,
+    "eliminations": 4,
+    "weaponDamage": 959,
+    "otherDamage": 400,
+    "revives": 1,
+    "damageTaken": 1192,
+    "damageToStructures": 1983,
+    "materialsGathered": 0,
+    "materialsUsed": 0,
+    "totalTraveled": 2
+  },
+  "teamMatchStats": {
+    "position": 5,
+    "totalPlayers": 38
+  },
+  "eliminations": [
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27437.69493140945,
+            "y": -31942.42478480319,
+            "z": 3156.0806741491106
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 74648
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27274.612902258716,
+            "y": -31637.432156808012,
+            "z": 3131.029478083076
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 76921
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29599.00470539054,
+            "y": -30893.979701618347,
+            "z": 4014.891587655012
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 77389
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26537.931258223,
+            "y": -35394.32164989586,
+            "z": 3157.150001749481
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 77678
+    },
+    {
+      "eliminated": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26546.44099707215,
+            "y": -31615.228910032583,
+            "z": 3168.2388447255616
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 79626
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26309.93147018449,
+            "y": -34955.61542244628,
+            "z": 3124.0147414059293
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 81001
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29656.77811917098,
+            "y": -30931.935509470237,
+            "z": 3900.1500030514053
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 81324
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -31982.21994196017,
+            "y": -42769.735349085226,
+            "z": 3122.6961371922243
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 81952
+    },
+    {
+      "eliminated": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26619.88495161576,
+            "y": -31532.155729321476,
+            "z": 3142.9217405389545
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 83254
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -31896.474602818183,
+            "y": -42419.65454659388,
+            "z": 3123.988009780211
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 84640
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26602.166729953737,
+            "y": -33309.25373165941,
+            "z": 3172.750321465556
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 100960
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27101.90101796411,
+            "y": -33076.560177142535,
+            "z": 3149.1097764665597
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 103665
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25583.255386237848,
+            "y": -37174.3396793377,
+            "z": 3149.198688413306
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 104371
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26780.226354504186,
+            "y": -32922.924109019346,
+            "z": 3124.1500032721206
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 106071
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -23148.65878369921,
+            "y": -36921.817993373974,
+            "z": 3180.9986952618183
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 106646
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27170.102267100545,
+            "y": -33020.64833868412,
+            "z": 3124.111775367927
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 106697
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -22959.38384269279,
+            "y": -37086.73447450393,
+            "z": 3158.24402371043
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 109207
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25408.26419061281,
+            "y": -36934.71112200759,
+            "z": 3133.719603457346
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 109218
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25844.079989810554,
+            "y": -32419.960006094545,
+            "z": 3149.3860380369247
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 114473
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25734.83994897496,
+            "y": -33003.295465087576,
+            "z": 3124.388036938292
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 117835
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25657.069598625014,
+            "y": -33085.621245297705,
+            "z": 3172.7166206119164
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 124847
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24758.11957997692,
+            "y": -31961.386448048026,
+            "z": 3149.1500081150944
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 132002
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24657.719238522444,
+            "y": -32006.614653842193,
+            "z": 3146.888345857104
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 134719
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28782.28761644133,
+            "y": -39124.95256269356,
+            "z": 3149.0157528167233
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 137849
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18388.95988795134,
+            "y": -37191.14865309321,
+            "z": 2362.0789745317616
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 140162
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28870.884650215732,
+            "y": -39458.25948707578,
+            "z": 3124.0177517180905
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 141768
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18316.126188786362,
+            "y": -36872.36116438954,
+            "z": 2330.0239283552132
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 142718
+    },
+    {
+      "eliminated": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26743.246706187798,
+            "y": -42078.09540878355,
+            "z": 3300.367074759781
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 156401
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27044.7145376766,
+            "y": -42769.31705347848,
+            "z": 3213.0359377973014
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 157450
+    },
+    {
+      "eliminated": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19080.078542984025,
+            "y": -37451.821313460525,
+            "z": 2409.047177180166
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 159649
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26756.99195663621,
+            "y": -42321.372994429876,
+            "z": 3248.2314993670348
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 161282
+    },
+    {
+      "eliminated": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18926.21840071955,
+            "y": -37508.2446180928,
+            "z": 2409.0526224986415
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 162681
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27870.652441840273,
+            "y": -31618.117776934454,
+            "z": 3156.0295050229333
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 169700
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27900.482919761533,
+            "y": -31667.64646224616,
+            "z": 3147.750333425767
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 173539
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26688.699752564262,
+            "y": -32230.336863298224,
+            "z": 3159.741853594187
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 174589
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26583.631199030242,
+            "y": -32790.83057138343,
+            "z": 3149.733554744343
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 188193
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26513.117003457442,
+            "y": -32851.77376349866,
+            "z": 3124.413508253414
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 191224
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26963.166342591743,
+            "y": -32641.62931240677,
+            "z": 4284.1499886297615
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 212580
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26450.232815869495,
+            "y": -32576.54302282092,
+            "z": 3151.632719120439
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 213670
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26193.67428927775,
+            "y": -32315.79304288063,
+            "z": 3150.94348330623
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 214036
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27030.726273092307,
+            "y": -32518.039580124194,
+            "z": 4284.1499886297615
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 215464
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26354.43095379086,
+            "y": -32547.49823305024,
+            "z": 3125.907644231211
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 217242
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27937.69253559056,
+            "y": -33171.665431598914,
+            "z": 3149.1500010102122
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 227405
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28635.95866777772,
+            "y": -41458.621093554604,
+            "z": 3149.150001651834
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 230027
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28048.135909318717,
+            "y": -32201.356769115715,
+            "z": 3152.2392005917304
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 230444
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27949.40818172314,
+            "y": -33177.36067774146,
+            "z": 3149.152000498584
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 231885
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28062.9527572882,
+            "y": -32518.802649548514,
+            "z": 3124.2729257319857
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 233495
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28569.973958036906,
+            "y": -41943.152366057875,
+            "z": 3124.1500014891176
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 233591
+    },
+    {
+      "eliminated": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28338.04258647948,
+            "y": -42252.72355887264,
+            "z": 3538.8521151411237
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 236999
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28349.386315034517,
+            "y": -33311.35543402896,
+            "z": 3124.150000627809
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 239594
+    },
+    {
+      "eliminated": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29208.641880625117,
+            "y": -41539.202666604804,
+            "z": 2981.0792851783863
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 239907
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28118.809778007013,
+            "y": -32515.746979282594,
+            "z": 3149.3101957543763
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 244876
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -16813.04853635607,
+            "y": -19296.15209901316,
+            "z": 4956.037770745849
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 248398
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28109.24767104311,
+            "y": -32775.51979345696,
+            "z": 3147.6923113518314
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 249075
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -16704.3121650316,
+            "y": -18278.8486819623,
+            "z": 3128.2337043865546
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 251282
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28098.34583445358,
+            "y": -32410.922524073223,
+            "z": 3124.3121946557435
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 251937
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -27820.116884103893,
+            "y": -33035.177237394615,
+            "z": 3124.3204746840856
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 254412
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29497.321400182453,
+            "y": -32923.76268273303,
+            "z": 3152.8558728579083
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 279247
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29560.313082761226,
+            "y": -32954.661989550295,
+            "z": 3129.461667988118
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": false,
+      "timestamp": 282598
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29883.730005774472,
+            "y": -31523.14341408513,
+            "z": 3156.029444197307
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 292857
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29242.66980401776,
+            "y": -32171.99562741046,
+            "z": 3131.291376938976
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 294327
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28169.97560380977,
+            "y": -30682.34422072608,
+            "z": 3925.149985066229
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 295068
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29383.98918376312,
+            "y": -32142.54897745655,
+            "z": 3156.029370488117
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 295566
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 41895.58216078388,
+            "y": -3013.808410458049,
+            "z": 4309.150020007012
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 296753
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28358.658775769993,
+            "y": -30540.291953543594,
+            "z": 3900.1509845169126
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 297628
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29261.86976811993,
+            "y": -32537.692214496547,
+            "z": 3149.577448625753
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 298533
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 41544.38938096948,
+            "y": -2646.518736088832,
+            "z": 4276.367892785426
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 299991
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -29137.15524934632,
+            "y": -32692.549898889923,
+            "z": 3147.7494378969686
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 300148
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -28988.5711812994,
+            "y": -32745.14905178571,
+            "z": 3147.7503354342684
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 301597
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 39097.372263565914,
+            "y": -4818.795290727263,
+            "z": 3994.8013047110494
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 307850
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15231.55761190052,
+            "y": -39038.15281535027,
+            "z": 2277.0047027952505
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 308205
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18450.12707416041,
+            "y": -2409.9895312294498,
+            "z": 2416.1505625109376
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9142097557035305,
+            "w": 0.40524131400498986
+          },
+          "position": {
+            "x": -16572.9921875,
+            "y": -4359.1875,
+            "z": 2434.1953125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 308851
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14985.480728958326,
+            "y": -39062.24259176219,
+            "z": 2317.308451846667
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 310445
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18490.664621894302,
+            "y": -2423.2339955833722,
+            "z": 2415.981750506229
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9300077955083833,
+            "w": 0.36753979416334914
+          },
+          "position": {
+            "x": -17804.2734375,
+            "y": -2881.4140625,
+            "z": 2444.84375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 312054
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 39618.9523486296,
+            "y": -4516.696707072434,
+            "z": 4167.1275025500745
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 313780
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 39070.85607563108,
+            "y": -3969.9987296282893,
+            "z": 4241.339238585709
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 313915
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 39382.24983481552,
+            "y": -5063.366241776983,
+            "z": 3900.0022851311705
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 317958
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 40998.63184022022,
+            "y": -1694.170143319301,
+            "z": 5664.646037470642
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 342960
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17965.03888077678,
+            "y": -27267.25567587117,
+            "z": 3064.4781766948413
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9155390911128687,
+            "w": 0.4022290052249117
+          },
+          "position": {
+            "x": -17609.5703125,
+            "y": -26827.7265625,
+            "z": 2939.5078125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 345057
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17973.895729201442,
+            "y": -26870.968506777892,
+            "z": 2952.1615491637267
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6986199358256688,
+            "w": 0.7154929666089938
+          },
+          "position": {
+            "x": -17891.5,
+            "y": -27230.9375,
+            "z": 2943.5546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 350800
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 40881.62134467577,
+            "y": -1883.4752553250594,
+            "z": 5052.150003018144
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 351262
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12260.51962211014,
+            "y": -7498.949970863476,
+            "z": 2361.500608445393
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.6897304939524921,
+            "w": 0.7240661887645711
+          },
+          "position": {
+            "x": -12352.46875,
+            "y": -6767.3125,
+            "z": 2515.984375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 353678
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -31044.58873581328,
+            "y": -9708.498335994076,
+            "z": 4293.713924970106
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.4518594787569548,
+            "w": 0.8920891275301437
+          },
+          "position": {
+            "x": -31184.7265625,
+            "y": -9833.203125,
+            "z": 4188.609375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 355251
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17888.387566408208,
+            "y": -6544.635295724537,
+            "z": 2694.7205385000416
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7249993478486981,
+            "w": 0.6887495521733299
+          },
+          "position": {
+            "x": -17849.7734375,
+            "y": -7138.0703125,
+            "z": 2945.125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 356741
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26430.473585548592,
+            "y": -10079.922659798109,
+            "z": 2781.2749952428367
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.013746211597779544,
+            "w": 0.9999055163697764
+          },
+          "position": {
+            "x": -27144.671875,
+            "y": -10158.96875,
+            "z": 2881.640625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "0d",
+      "knocked": true,
+      "timestamp": 357068
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12241.92349239712,
+            "y": -7292.371197774134,
+            "z": 2361.500608445393
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.15877363160379396,
+            "w": 0.9873150124997303
+          },
+          "position": {
+            "x": -12407.765625,
+            "y": -7276.203125,
+            "z": 2386.5
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 357650
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12407.764944069784,
+            "y": -7276.200561311576,
+            "z": 2386.5006206065364
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7069048630283544,
+            "w": 0.7073086417023785
+          },
+          "position": {
+            "x": -12477.984375,
+            "y": -3802.8125,
+            "z": 2302.90625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 357897
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -31040.111408794528,
+            "y": -9761.2372141236,
+            "z": 4272.071957266833
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.5073832576829933,
+            "w": 0.8617205056298666
+          },
+          "position": {
+            "x": -31185.4765625,
+            "y": -9608.9375,
+            "z": 4188.15625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 358280
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17885.042164295875,
+            "y": -6295.5761151894685,
+            "z": 2748.149986327026
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6618206169288625,
+            "w": 0.7496622379497984
+          },
+          "position": {
+            "x": -17866.578125,
+            "y": -6367.46875,
+            "z": 2817.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 360126
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25264.711106033305,
+            "y": -9954.57759559695,
+            "z": 2748.1500029098825
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.21827440102000556,
+            "w": 0.9758874350350855
+          },
+          "position": {
+            "x": -25893.8359375,
+            "y": -10398.15625,
+            "z": 2781.2734375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 361024
+    },
+    {
+      "eliminated": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26525.349003974872,
+            "y": -9950.093434628245,
+            "z": 2748.1520017735984
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.03680722294135883,
+            "w": 0.9993223845883497
+          },
+          "position": {
+            "x": -26933.375,
+            "y": -9931.6875,
+            "z": 2748.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "0d",
+      "knocked": false,
+      "timestamp": 361324
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12982.715549489372,
+            "y": -6876.878783837069,
+            "z": 2400.8042269188823
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9853034466121386,
+            "w": 0.17081310867214022
+          },
+          "position": {
+            "x": -12850.914905997937,
+            "y": -6864.666542338475,
+            "z": 2391.1017675008447
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 363131
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25282.903926930474,
+            "y": -10083.775348788906,
+            "z": 2748.1500001615987
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8760700941954066,
+            "w": 0.48218377207912266
+          },
+          "position": {
+            "x": -25190.25,
+            "y": -10214.3984375,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 363374
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17850.691486774675,
+            "y": -6399.865981730082,
+            "z": 2802.82915642937
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.679713066382563,
+            "w": 0.7334781165030172
+          },
+          "position": {
+            "x": -17964.0859375,
+            "y": -6274.5859375,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 365186
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12747.457024035406,
+            "y": -6906.409539296352,
+            "z": 2362.7771052697053
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.12871664902263574,
+            "w": 0.9916814126847306
+          },
+          "position": {
+            "x": -13439.460571255444,
+            "y": -7185.593025061451,
+            "z": 2506.375957211648
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 365447
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -17913.3697358441,
+            "y": -6016.011889067321,
+            "z": 3078.9067281280995
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7593684198682805,
+            "w": 0.6506608970168339
+          },
+          "position": {
+            "x": -17781.8125,
+            "y": -6313.2421875,
+            "z": 2871.5234375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 368063
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25002.755702959563,
+            "y": -9978.958752423223,
+            "z": 2773.14999841975
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6761911177236448,
+            "w": 0.7367262533069173
+          },
+          "position": {
+            "x": -24990.1875,
+            "y": -10300.75,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 370823
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24976.462739050647,
+            "y": -9734.167369866062,
+            "z": 2773.14999746136
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.3478596041996883,
+            "w": 0.9375466365819016
+          },
+          "position": {
+            "x": -25524.359375,
+            "y": -10451.859375,
+            "z": 2781.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 372402
+    },
+    {
+      "eliminated": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -10343.399635373456,
+            "y": 2052.2508726634323,
+            "z": 2364.3787000876687
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "92ad069663fc4029a1d8f1ea936a33ab",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.00956918399057288,
+            "w": 0.9999542143107127
+          },
+          "position": {
+            "x": -11615.5703125,
+            "y": 1967.0625,
+            "z": 2427.2265625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 374632
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25028.043653158657,
+            "y": -9393.545353834192,
+            "z": 2748.1509969120434
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9415440651830207,
+            "w": 0.3368898533922201
+          },
+          "position": {
+            "x": -25008.3359375,
+            "y": -10271.8125,
+            "z": 2748.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 376833
+    },
+    {
+      "eliminated": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -10254.66437679313,
+            "y": 2075.2818116909257,
+            "z": 2341.400020838959
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.18934847744673042,
+            "w": 0.9819099521283023
+          },
+          "position": {
+            "x": -10384.4140625,
+            "y": 2064.5234375,
+            "z": 2364.28125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 377073
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 30591.732024192388,
+            "y": 136.4626640896395,
+            "z": 2097.6944970959635
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 380405
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 30318.121138200568,
+            "y": 16.99816597585976,
+            "z": 2028.1216042766223
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 383445
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 38440.36760844017,
+            "y": -2066.3785562704993,
+            "z": 4238.060852776827
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": true,
+      "timestamp": 384848
+    },
+    {
+      "eliminated": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -11992.010761170517,
+            "y": -6142.098606405127,
+            "z": 2957.057293244701
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9632905923905506,
+            "w": 0.2684608623465673
+          },
+          "position": {
+            "x": -11703.3203125,
+            "y": -6347.734375,
+            "z": 2576.7265625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 387144
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 38142.366842795665,
+            "y": -2386.00122924769,
+            "z": 4146.463605969728
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": false,
+      "timestamp": 388296
+    },
+    {
+      "eliminated": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -11933.544418368283,
+            "y": -5903.077035966629,
+            "z": 2351.3481437447695
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.997224522838237,
+            "w": 0.07445301236384018
+          },
+          "position": {
+            "x": -11623.1015625,
+            "y": -5881.78125,
+            "z": 2376.25
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 390407
+    },
+    {
+      "eliminated": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 35657.04307117278,
+            "y": -4739.107646766891,
+            "z": 3463.211947645385
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 395794
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20018.6151041211,
+            "y": -11967.34629003849,
+            "z": 5155.209507439639
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.8625296993588616,
+            "w": 0.506006440397661
+          },
+          "position": {
+            "x": -19828.8203125,
+            "y": -11460.734375,
+            "z": 5056.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 396011
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19881.801917905043,
+            "y": 4529.1824546959315,
+            "z": 2922.3691817193458
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.2667127574748984,
+            "w": 0.9637760657954401
+          },
+          "position": {
+            "x": -24590.4140625,
+            "y": 7360,
+            "z": 2446.390625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 397150
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 35372.32518166826,
+            "y": -1457.6358351208964,
+            "z": 2876.692933606924
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 398297
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25359.58480156582,
+            "y": -8253.564180011048,
+            "z": 3156.6507547866395
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7730208694787227,
+            "w": 0.6343805918771157
+          },
+          "position": {
+            "x": -25222.203125,
+            "y": -8451.984375,
+            "z": 3156.6484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 398703
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20046.78582934859,
+            "y": -11912.25918089343,
+            "z": 5120.100852993308
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8960426547391765,
+            "w": 0.4439679728178246
+          },
+          "position": {
+            "x": -20842.1796875,
+            "y": -11871.5703125,
+            "z": 5461.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 399365
+    },
+    {
+      "eliminated": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 35420.02690086694,
+            "y": -5188.308467620972,
+            "z": 3313.650038114379
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 400058
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25472.61299790012,
+            "y": -8268.999902295991,
+            "z": 3131.6527536880067
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.99931881290374,
+            "w": 0.03690406721026801
+          },
+          "position": {
+            "x": -25404.9375,
+            "y": -8255.3359375,
+            "z": 3156.65625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 401522
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 34206.79895800615,
+            "y": -1666.6877559181723,
+            "z": 2631.0097771384126
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "f25f0977f2ea4f549fce28b3f9760557",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 404199
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12013.087386315956,
+            "y": 8100.272132370782,
+            "z": 2531.2809120134452
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7930102365742762,
+            "w": 0.609208309766381
+          },
+          "position": {
+            "x": -11951.328125,
+            "y": 8121.2109375,
+            "z": 2521.3515625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 407221
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20725.54404800407,
+            "y": -12576.436522479376,
+            "z": 5088.789313722952
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7644764367685624,
+            "w": 0.6446516715449069
+          },
+          "position": {
+            "x": -20716.203125,
+            "y": -12184.1875,
+            "z": 5344.0078125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 407767
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24686.269161848086,
+            "y": -8709.520515242115,
+            "z": 2773.1500027107286
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7600279229938676,
+            "w": 0.6498904186627373
+          },
+          "position": {
+            "x": -24662.2578125,
+            "y": -9039.9609375,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 409381
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12163.80136724894,
+            "y": 8258.694355997715,
+            "z": 2547.9884878228136
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9873014181578583,
+            "w": 0.15885814333386142
+          },
+          "position": {
+            "x": -12047.8046875,
+            "y": 8328.5,
+            "z": 2567.875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 409706
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19939.812613807393,
+            "y": 4421.437192292497,
+            "z": 1658.4626894110372
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.36000344041316934,
+            "w": 0.9329509756094806
+          },
+          "position": {
+            "x": -21681.34375,
+            "y": 2816.9296875,
+            "z": 2201.890625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 410982
+    },
+    {
+      "eliminated": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20184.19196253715,
+            "y": -11820.081839275648,
+            "z": 5096.542175010754
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5967295751574179,
+            "w": 0.8024424054924115
+          },
+          "position": {
+            "x": -20181.859375,
+            "y": -11890.921875,
+            "z": 5130.078125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 411388
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25536.937174554976,
+            "y": -9346.196125918772,
+            "z": 2781.1415773778203
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9823503094182205,
+            "w": 0.18705044663385983
+          },
+          "position": {
+            "x": -25287.234375,
+            "y": -9170.375,
+            "z": 2748.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 412157
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24701.575813097403,
+            "y": -8810.923178397377,
+            "z": 2748.152001612096
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6704194674538003,
+            "w": 0.7419823027936467
+          },
+          "position": {
+            "x": -24666.84375,
+            "y": -8863.203125,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 412682
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -25962.561988549,
+            "y": -9611.229792855624,
+            "z": 2756.1435762791875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9546603498232553,
+            "w": 0.29769718922982785
+          },
+          "position": {
+            "x": -25886.0703125,
+            "y": -9566.7421875,
+            "z": 2781.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 415328
+    },
+    {
+      "eliminated": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19859.78170992759,
+            "y": 4625.276760006613,
+            "z": 1623.4679803978331
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.3020059493192282,
+            "w": 0.9533060403541939
+          },
+          "position": {
+            "x": -20137.4140625,
+            "y": 4370.5859375,
+            "z": 1717.65625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 415683
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12365.427762418374,
+            "y": -6351.114259218958,
+            "z": 2368.149974611679
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 419164
+    },
+    {
+      "eliminated": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12612.877949905036,
+            "y": -5926.756717557933,
+            "z": 2632.9680629220147
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.08401478199828553,
+            "w": 0.9964645083522947
+          },
+          "position": {
+            "x": -12796.5234375,
+            "y": -5935.2421875,
+            "z": 2351.2265625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 424519
+    },
+    {
+      "eliminated": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12515.135660034499,
+            "y": -6062.177601175806,
+            "z": 2417.2456158674895
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.8868850158218398,
+            "w": 0.46199022577398197
+          },
+          "position": {
+            "x": -12293.171875,
+            "y": -6161,
+            "z": 2392.9375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 427751
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18940.30451597859,
+            "y": 10948.716407082618,
+            "z": 2393.130513058595
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.30923446150303546,
+            "w": 0.9509858294522204
+          },
+          "position": {
+            "x": -19304.4921875,
+            "y": 10706.53125,
+            "z": 2389.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 429302
+    },
+    {
+      "eliminated": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19056.592266545813,
+            "y": 10848.477061411311,
+            "z": 2368.15000893838
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9983591275843062,
+            "w": 0.05726301047886815
+          },
+          "position": {
+            "x": -18867.203125,
+            "y": 10930.8828125,
+            "z": 2393.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 432616
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20218.549056851516,
+            "y": 4098.503620779109,
+            "z": 1740.3897968204174
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.08579672976086127,
+            "w": 0.9963126623517045
+          },
+          "position": {
+            "x": -28729.3359375,
+            "y": 2688.21875,
+            "z": 5383.84375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 433124
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -20596.70514234003,
+            "y": -12341.606516475838,
+            "z": 5112.506677370627
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9999999999999999,
+            "w": 6.123233995736766e-17
+          },
+          "position": {
+            "x": -19437.109375,
+            "y": -12349.7734375,
+            "z": 5281.8125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 434083
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19811.585206320065,
+            "y": -12434.574046487654,
+            "z": 5225.236005737348
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.19824954623213809,
+            "w": 0.9801515787972549
+          },
+          "position": {
+            "x": -19869.4453125,
+            "y": -12410.8203125,
+            "z": 5239.578125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 437468
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19467.701810535476,
+            "y": 4161.240593567779,
+            "z": 1611.3994731985322
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.08579661548732742,
+            "w": 0.9963126721922789
+          },
+          "position": {
+            "x": -28495.1953125,
+            "y": 2569.1796875,
+            "z": 5350.4453125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 438767
+    },
+    {
+      "eliminated": {
+        "id": "9a24d3c010974e829b6cdc219bf75482",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14685.243434058599,
+            "y": 9444.771320969736,
+            "z": 1880.9503599421528
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5143511202214941,
+            "w": 0.8575796902486054
+          },
+          "position": {
+            "x": -16001.8046875,
+            "y": 7050.59375,
+            "z": 1644.1171875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 442609
+    },
+    {
+      "eliminated": {
+        "id": "9a24d3c010974e829b6cdc219bf75482",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14297.160167170494,
+            "y": 9525.185121415972,
+            "z": 1758.7794558201194
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.3713171939518377,
+            "w": 0.9285060804732155
+          },
+          "position": {
+            "x": -14652.53125,
+            "y": 9102.9140625,
+            "z": 1754.0859375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 449053
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26655.61936489793,
+            "y": 8137.364276344787,
+            "z": 2451.740594422798
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9909027944264381,
+            "w": 0.13457953781268422
+          },
+          "position": {
+            "x": -24363.328125,
+            "y": 8822.75,
+            "z": 2431.328125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 461341
+    },
+    {
+      "eliminated": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24708.327660770403,
+            "y": 7071.582357916928,
+            "z": 2543.966907611265
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6632884218558248,
+            "w": 0.7483638616555516
+          },
+          "position": {
+            "x": -24868.328125,
+            "y": 6912.0859375,
+            "z": 2666.5703125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 466373
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18443.704572354916,
+            "y": 4828.555446450818,
+            "z": 1675.8045592843116
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9039892931234434,
+            "w": 0.4275550934302816
+          },
+          "position": {
+            "x": -14620.875,
+            "y": 9725.2578125,
+            "z": 1721.1015625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "06",
+      "knocked": true,
+      "timestamp": 467912
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -26162.134466323525,
+            "y": 8048.525547585372,
+            "z": 2451.4825503391644
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.965322235873368,
+            "w": 0.26106125895743704
+          },
+          "position": {
+            "x": -24427.2890625,
+            "y": 7061.6484375,
+            "z": 2438.234375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 470762
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -18775.827177926483,
+            "y": 4605.86427814758,
+            "z": 1673.3259441113576
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.935395926062244,
+            "w": 0.3536021231640968
+          },
+          "position": {
+            "x": -14662.7265625,
+            "y": 9622.9140625,
+            "z": 1729.25
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "06",
+      "knocked": false,
+      "timestamp": 470960
+    },
+    {
+      "eliminated": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -24621.56836514727,
+            "y": 6795.292231253459,
+            "z": 2437.589198158839
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.549479617315017,
+            "w": 0.835507121546754
+          },
+          "position": {
+            "x": -25237.8359375,
+            "y": 8299.265625,
+            "z": 2453.9140625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 472478
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4892.271918214244,
+            "y": 6249.040884734207,
+            "z": 2416.1405159748065
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.1289675698890453,
+            "w": 0.9916488117861655
+          },
+          "position": {
+            "x": 4148.1484375,
+            "y": 5990.6796875,
+            "z": 2389.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 473717
+    },
+    {
+      "eliminated": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9680.834302926232,
+            "y": -7424.201087404754,
+            "z": 2401.3264297364135
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9435932566098268,
+            "w": 0.3311068801466701
+          },
+          "position": {
+            "x": -9218.2734375,
+            "y": -6974.1953125,
+            "z": 2481.34375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 476108
+    },
+    {
+      "eliminated": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 5024.933070692441,
+            "y": 3682.6094129714866,
+            "z": 2346.401572036234
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.6314624850077964,
+            "w": 0.7754064289311628
+          },
+          "position": {
+            "x": 4414.09375,
+            "y": 6112.0859375,
+            "z": 2381.03125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 477166
+    },
+    {
+      "eliminated": {
+        "id": "d7f9ce75b53e4777b9e59a238a56d26e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15415.996789425986,
+            "y": 9912.729242755835,
+            "z": 1650.3857236473912
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.46053896123395116,
+            "w": 0.8876394905509516
+          },
+          "position": {
+            "x": -18867.109375,
+            "y": 5037.3203125,
+            "z": 1696.0078125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 478018
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4722.729779312799,
+            "y": 5914.710122128587,
+            "z": 2357.7734065727127
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7716106851265512,
+            "w": 0.6360950798414765
+          },
+          "position": {
+            "x": 5048.2578125,
+            "y": 3609.2421875,
+            "z": 2347.578125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 479298
+    },
+    {
+      "eliminated": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 5125.778486686138,
+            "y": 3556.669259217008,
+            "z": 2349.0393003687186
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7156568370509647,
+            "w": 0.6984520682066946
+          },
+          "position": {
+            "x": 4933.4453125,
+            "y": 4730.0859375,
+            "z": 2631.6875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 480244
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14678.757472469168,
+            "y": 9657.880514558161,
+            "z": 1730.8366883951105
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.39411002993037153,
+            "w": 0.919063264584262
+          },
+          "position": {
+            "x": -18863.6953125,
+            "y": 5102.7265625,
+            "z": 1695.875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 480637
+    },
+    {
+      "eliminated": {
+        "id": "d7f9ce75b53e4777b9e59a238a56d26e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14886.053293615269,
+            "y": 9713.025774782362,
+            "z": 1741.9612790841265
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5490701348215755,
+            "w": 0.8357762781073754
+          },
+          "position": {
+            "x": -17891.078125,
+            "y": 6115.2890625,
+            "z": 1772.34375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 483229
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15114.765581234427,
+            "y": -15342.61274798304,
+            "z": 2535.165265173333
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.2767999332572364,
+            "w": 0.9609275711253111
+          },
+          "position": {
+            "x": -15627.890625,
+            "y": -15125.65625,
+            "z": 2773.4375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 483751
+    },
+    {
+      "eliminated": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9389.109912221404,
+            "y": -7546.542926394592,
+            "z": 2385.653072197838
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.2560468386497561,
+            "w": 0.9666643763051714
+          },
+          "position": {
+            "x": -9842.546875,
+            "y": -7665.7578125,
+            "z": 2401.3359375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 483767
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -14841.126596306667,
+            "y": 9667.350010185155,
+            "z": 1757.7893621256512
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.47139673682599764,
+            "w": 0.8819212643483548
+          },
+          "position": {
+            "x": -17288.484375,
+            "y": 6529.8203125,
+            "z": 1394.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 484332
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8663.900808101882,
+            "y": -7237.497155256167,
+            "z": 2417.9795225759826
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.019589335176694533,
+            "w": 0.9998081105628897
+          },
+          "position": {
+            "x": -9286.015625,
+            "y": -7316.125,
+            "z": 2404.0390625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 488744
+    },
+    {
+      "eliminated": {
+        "id": "9a24d3c010974e829b6cdc219bf75482",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19607.59738286676,
+            "y": 7183.411694010589,
+            "z": 2331.7094080450815
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9957117612608517,
+            "w": 0.0925099372327777
+          },
+          "position": {
+            "x": -16947.796875,
+            "y": 6688.0859375,
+            "z": 1527.4140625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 488946
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15910.74950936856,
+            "y": -15842.002975794583,
+            "z": 2687.3242654012765
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9503723943144573,
+            "w": 0.3111146285937158
+          },
+          "position": {
+            "x": -15702.515625,
+            "y": -15726.828125,
+            "z": 2661.328125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 489883
+    },
+    {
+      "eliminated": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9403.275911990584,
+            "y": -7390.173034132896,
+            "z": 2378.9694165279716
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7894350305060506,
+            "w": 0.6138341246704284
+          },
+          "position": {
+            "x": -9373.3125,
+            "y": -7174.265625,
+            "z": 2401.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 491046
+    },
+    {
+      "eliminated": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9318.194939142888,
+            "y": -7636.916303218033,
+            "z": 2395.1177052482667
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5175727484512598,
+            "w": 0.8556392055420374
+          },
+          "position": {
+            "x": -9626.963352101053,
+            "y": -8331.383059241114,
+            "z": 2433.532774998901
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 492210
+    },
+    {
+      "eliminated": {
+        "id": "9a24d3c010974e829b6cdc219bf75482",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -19937.843311921806,
+            "y": 7022.739624934256,
+            "z": 2343.79925890333
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7611977193058753,
+            "w": 0.6485198779710103
+          },
+          "position": {
+            "x": -14868.546875,
+            "y": 8848.3515625,
+            "z": 1705.6640625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 494447
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12306.836172213027,
+            "y": -14776.787689343328,
+            "z": 2831.6965955398573
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.1553256327334324,
+            "w": 0.9878633244614148
+          },
+          "position": {
+            "x": -16360.8125,
+            "y": -13495.0390625,
+            "z": 6101.734375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 498719
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9153.112157064987,
+            "y": -7071.047514428158,
+            "z": 2400.150757934665
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7109639635452721,
+            "w": 0.7032284426415055
+          },
+          "position": {
+            "x": -9143.57984877215,
+            "y": -6989.819534041543,
+            "z": 2374.995843969952
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 500412
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -12288.806778459279,
+            "y": -15052.308957401774,
+            "z": 2748.1500002863586
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7324892499717128,
+            "w": 0.6807785973985065
+          },
+          "position": {
+            "x": -12312.5234375,
+            "y": -14797.5625,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 501596
+    },
+    {
+      "eliminated": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9153.00673407448,
+            "y": -6797.892912230277,
+            "z": 2372.888164584151
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.19509032201612828,
+            "w": 0.9807852804032304
+          },
+          "position": {
+            "x": -9534.703125,
+            "y": -7161.65625,
+            "z": 2376.2265625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 502319
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8792.830305352327,
+            "y": -6989.061743778943,
+            "z": 2373.3839499016754
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9715856092752273,
+            "w": 0.2366884108892649
+          },
+          "position": {
+            "x": -9621.35948128129,
+            "y": -7519.133855969268,
+            "z": 2403.715372516981
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 503289
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -903.5158921499064,
+            "y": -7358.526873803494,
+            "z": 1974.5020311063588
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6768291071667543,
+            "w": 0.736140176659211
+          },
+          "position": {
+            "x": -913.8984375,
+            "y": -8496.8671875,
+            "z": 1948.0390625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 523577
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9603.111244605088,
+            "y": 8719.433213614338,
+            "z": 4870.536747764167
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6173969849288703,
+            "w": 0.7866517418786667
+          },
+          "position": {
+            "x": -9666.390625,
+            "y": 8451.609375,
+            "z": 4697.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 524502
+    },
+    {
+      "eliminated": {
+        "id": "839f712b36ee448cb73bde8d575b2c2c",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1235.3908521451604,
+            "y": -7020.162952620285,
+            "z": 2015.2342489058785
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.698356625058554,
+            "w": 0.7157499732705732
+          },
+          "position": {
+            "x": -1205.390625,
+            "y": -7339.390625,
+            "z": 2055.2578125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 526679
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9462.799966595026,
+            "y": 7979.528650527317,
+            "z": 4672.15000167435
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.6531728429537768,
+            "w": 0.7572088465064847
+          },
+          "position": {
+            "x": -9524.1796875,
+            "y": 8235.078125,
+            "z": 4697.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 527313
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -970.1991780922381,
+            "y": -6409.136144383775,
+            "z": 2095.3653539409643
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9689121142103646,
+            "w": 0.24740516352008812
+          },
+          "position": {
+            "x": -412.5546875,
+            "y": -6099.9921875,
+            "z": 1984.453125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 537567
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -6135.92163271432,
+            "y": -12886.422702737944,
+            "z": 2005.1499792115164
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7330089636740909,
+            "w": 0.6802189788394878
+          },
+          "position": {
+            "x": -6153.59375,
+            "y": -12650.8515625,
+            "z": 2030.3828125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 539833
+    },
+    {
+      "eliminated": {
+        "id": "6ac591f301094016a8a2f83d6cb917e2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -11.747752412877757,
+            "y": -6056.78693592238,
+            "z": 1952.9672334735028
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.5555702330196021,
+            "w": 0.8314696123025453
+          },
+          "position": {
+            "x": -984.78125,
+            "y": -6558.1328125,
+            "z": 1992.9375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 541238
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -6245.213417170167,
+            "y": -12936.528771654614,
+            "z": 2005.1509889878273
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.4688232988954383,
+            "w": 0.8832919757434674
+          },
+          "position": {
+            "x": -6259.234375,
+            "y": -13152.6953125,
+            "z": 1934.9375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 542314
+    },
+    {
+      "eliminated": {
+        "id": "2d926b34e51e4945ab16b40d535c1909",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -6252.4547268581755,
+            "y": -9107.04653559982,
+            "z": 3900.14998291137
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.10136686987820134,
+            "w": 0.9948491130272447
+          },
+          "position": {
+            "x": -6447.958796601195,
+            "y": -9108.390968600506,
+            "z": 3906.4167109799855
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 545154
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -6121.278000848378,
+            "y": -12794.624388695198,
+            "z": 1980.1499741635782
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5472664915738651,
+            "w": 0.8369584142598917
+          },
+          "position": {
+            "x": -6167.578125,
+            "y": -12918.515625,
+            "z": 2005.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 545273
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8021.021642026131,
+            "y": -15980.278960834632,
+            "z": 2393.149973238455
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9995634609824184,
+            "w": 0.029544669042814976
+          },
+          "position": {
+            "x": -7998.7890625,
+            "y": -15920.2578125,
+            "z": 2393.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 563049
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -5425.498816511517,
+            "y": -12584.324053253737,
+            "z": 1980.1499683053273
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.8577520589247676,
+            "w": 0.5140636200027403
+          },
+          "position": {
+            "x": -5186.5625,
+            "y": -11873.2265625,
+            "z": 2152.6796875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 564698
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8024.088376640869,
+            "y": -15629.528532943386,
+            "z": 2393.1499681855967
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.4347700438205941,
+            "w": 0.9005415087580574
+          },
+          "position": {
+            "x": -8057.9453125,
+            "y": -15738.4140625,
+            "z": 2368.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 566152
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8025.188368707748,
+            "y": -15520.312684351966,
+            "z": 2356.021572583508
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.5561055086199079,
+            "w": 0.831111703252092
+          },
+          "position": {
+            "x": -8348.296875,
+            "y": -15517.296875,
+            "z": 2364.15625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 567745
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8491.314356628847,
+            "y": -15233.313273079793,
+            "z": 2364.156676871965
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7514520380696004,
+            "w": 0.6597877192560074
+          },
+          "position": {
+            "x": -8449.515625,
+            "y": -15334.9765625,
+            "z": 2389.15625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 569795
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 7799.0334736623845,
+            "y": -3204.8288641258887,
+            "z": 1574.5593583262737
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.10743218199200484,
+            "w": 0.994212415066537
+          },
+          "position": {
+            "x": 7384.6640625,
+            "y": -3105.796875,
+            "z": 1593.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 571983
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9453.138294135728,
+            "y": -12151.506880372275,
+            "z": 2298.790098664421
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9671533851147894,
+            "w": 0.2541934886282574
+          },
+          "position": {
+            "x": -6942.8828125,
+            "y": -13349.171875,
+            "z": 1975.8828125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 572519
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 7845.10134507858,
+            "y": -3095.975724680654,
+            "z": 1536.9824986534575
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.030653835186315936,
+            "w": 0.9995300607727466
+          },
+          "position": {
+            "x": 7470.2265625,
+            "y": -3145.3203125,
+            "z": 1593.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 574294
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1842.8628597218842,
+            "y": 11780.118245534892,
+            "z": 2389.1500082352213
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9786138566424172,
+            "w": 0.20570590557262747
+          },
+          "position": {
+            "x": -1716.09375,
+            "y": 11695.6640625,
+            "z": 2389.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 576316
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -4995.052873162981,
+            "y": -12769.063455981475,
+            "z": 1904.1649682037112
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5574241496641282,
+            "w": 0.8302278707506895
+          },
+          "position": {
+            "x": -6655.2734375,
+            "y": -12189.84375,
+            "z": 2594.3046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 577301
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9502.794511133827,
+            "y": -11429.01195683329,
+            "z": 2480.914362123763
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8227998441819346,
+            "w": 0.5683312558835596
+          },
+          "position": {
+            "x": -8906.2578125,
+            "y": -12889.34375,
+            "z": 2199.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 577778
+    },
+    {
+      "eliminated": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -2160.0937984532297,
+            "y": 11571.853516255676,
+            "z": 2389.1500111320256
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9999999999997701,
+            "w": 6.779886295217378e-7
+          },
+          "position": {
+            "x": 2025.5625,
+            "y": 11620.84375,
+            "z": 2773.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 579408
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1806.904282184682,
+            "y": 11951.944790091296,
+            "z": 2364.1540060379557
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.318352024656525,
+            "w": 0.9479725673230693
+          },
+          "position": {
+            "x": -2257.9765625,
+            "y": 11571.8828125,
+            "z": 2364.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 579817
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8598.535505735965,
+            "y": -11691.746374564702,
+            "z": 2418.8997659840666
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.282196161820783,
+            "w": 0.9593567252349976
+          },
+          "position": {
+            "x": -10039.8828125,
+            "y": -12620.4296875,
+            "z": 2333.6875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 580747
+    },
+    {
+      "eliminated": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -2323.5715392306,
+            "y": 11621.362868600389,
+            "z": 2364.911219404399
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.4627144225398872,
+            "w": 0.886507396006135
+          },
+          "position": {
+            "x": -2442.09375,
+            "y": 11699.4609375,
+            "z": 2389.8359375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 581649
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9135.835673359508,
+            "y": -11909.531108464349,
+            "z": 2411.8825165930234
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7287217020978372,
+            "w": 0.6848099596907389
+          },
+          "position": {
+            "x": -9073.6875,
+            "y": -14846.2265625,
+            "z": 2356.0234375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 583414
+    },
+    {
+      "eliminated": {
+        "id": "590ca0e04c9e4422a0c593515da1328f",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8080.366772631982,
+            "y": -11684.354978062282,
+            "z": 2273.727614166311
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.23389037645162702,
+            "w": 0.9722629746129986
+          },
+          "position": {
+            "x": -8963.4140625,
+            "y": -11867.9765625,
+            "z": 2452.28125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 583688
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8573.352947460373,
+            "y": -11441.853523484937,
+            "z": 2499.4352999186144
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.953307231472224,
+            "w": 0.3020021894337255
+          },
+          "position": {
+            "x": -6872.9140625,
+            "y": -12619.8359375,
+            "z": 2012.4375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 589459
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9081.240720486143,
+            "y": -15360.443493100598,
+            "z": 2584.1575179944257
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9909026354277799,
+            "w": 0.134580708507126
+          },
+          "position": {
+            "x": 6332.859375,
+            "y": -11343.4296875,
+            "z": 2260.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 591556
+    },
+    {
+      "eliminated": {
+        "id": "e807caf8796b4e7dab3c67ad4f30b5a4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -9666.845756248298,
+            "y": -14886.931358769429,
+            "z": 2363.2811431836662
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9924795345987099,
+            "w": 0.12241067519921628
+          },
+          "position": {
+            "x": 6346.9140625,
+            "y": -11306.53125,
+            "z": 2260.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 594761
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8559.384515095244,
+            "y": -11328.599816507905,
+            "z": 2559.6434374967835
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6871786969641883,
+            "w": 0.7264884296660206
+          },
+          "position": {
+            "x": -8672.4609375,
+            "y": -14818.609375,
+            "z": 2364.21875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 595749
+    },
+    {
+      "eliminated": {
+        "id": "4797fa79bafa41ac89da8a10a07c481d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8601.770869372189,
+            "y": -11285.212965734085,
+            "z": 2583.4875138563075
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.698376249408973,
+            "w": 0.7157308252838187
+          },
+          "position": {
+            "x": -8668.15625,
+            "y": -14781.390625,
+            "z": 2364.21875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 597521
+    },
+    {
+      "eliminated": {
+        "id": "bfb28bb6f3a9465095fd563bb4a1c385",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8971.403669089266,
+            "y": -7426.042173078888,
+            "z": 2511.1239974230575
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9913931111206115,
+            "w": 0.13091867407896626
+          },
+          "position": {
+            "x": -7579.349952914145,
+            "y": -7774.330290270169,
+            "z": 3643.8351594426413
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 597570
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8621.239004073073,
+            "y": -11292.286105739775,
+            "z": 2605.5956485271086
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7474312413928679,
+            "w": 0.6643391749625464
+          },
+          "position": {
+            "x": -8001.5625,
+            "y": -15712.6796875,
+            "z": 2368.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 616318
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -10707.979983648509,
+            "y": 6561.033201160828,
+            "z": 2364.1500229590993
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.1515268277692781,
+            "w": 0.9884531453064325
+          },
+          "position": {
+            "x": -11277.2109375,
+            "y": 6651.78125,
+            "z": 2389.15625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": true,
+      "timestamp": 619388
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -10986.038736216018,
+            "y": 6524.68477478081,
+            "z": 2364.1500229590993
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9993473361993495,
+            "w": 0.03612342219758056
+          },
+          "position": {
+            "x": -10673.6328125,
+            "y": 6550.25,
+            "z": 2364.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": false,
+      "timestamp": 623971
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -10566.295669682524,
+            "y": -10698.377261162415,
+            "z": 2480.2288799695343
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7910168773863051,
+            "w": 0.6117943279322057
+          },
+          "position": {
+            "x": -9146.0546875,
+            "y": -15153.5546875,
+            "z": 2364.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 624935
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15336.43537447383,
+            "y": 6342.687081454698,
+            "z": 1682.8033576885991
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9256264931484656,
+            "w": 0.3784383637815719
+          },
+          "position": {
+            "x": -15284.1875,
+            "y": 6568.2890625,
+            "z": 1717.0703125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 627932
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -15241.948264371367,
+            "y": 6297.870661685355,
+            "z": 1683.1939816608071
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.07356456359966745,
+            "w": 0.9972904566786901
+          },
+          "position": {
+            "x": -14992.421875,
+            "y": 6759.2890625,
+            "z": 1960.4296875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 630647
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 17883.424345816293,
+            "y": -2507.2033802530805,
+            "z": 849.9982987908221
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ec5a21ed7d1e4d2ca68296f22b8b802d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6055110414043254,
+            "w": 0.7958369046088837
+          },
+          "position": {
+            "x": 18044.875,
+            "y": -2814.15625,
+            "z": 857.390625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 635392
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -7986.149013625849,
+            "y": -9686.344164249722,
+            "z": 3516.149971929721
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.14521884485840555,
+            "w": 0.989399558872951
+          },
+          "position": {
+            "x": -8058.125,
+            "y": -9758.1640625,
+            "z": 3541.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 637185
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8222.995730269651,
+            "y": -9850.941877480029,
+            "z": 3516.1519797611754
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.95804024698275,
+            "w": 0.2866337125343622
+          },
+          "position": {
+            "x": -8170.1953125,
+            "y": -9836.9453125,
+            "z": 3541.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 640212
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 18041.089152438504,
+            "y": -2496.928157795043,
+            "z": 850.2348597968335
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.11321851152044927,
+            "w": 0.993570112598549
+          },
+          "position": {
+            "x": 17848.578125,
+            "y": -2583.484375,
+            "z": 849.8046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 640850
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 14413.325366106043,
+            "y": -6413.936018494462,
+            "z": 936.6373426646126
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7491548414946043,
+            "w": 0.6623949150357319
+          },
+          "position": {
+            "x": 14977.5703125,
+            "y": -2020.3203125,
+            "z": 946.59375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 646596
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -5639.465888461357,
+            "y": -12783.873883033202,
+            "z": 2005.1519792103584
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.8847906738063325,
+            "w": 0.4659886946539968
+          },
+          "position": {
+            "x": -5564.6640625,
+            "y": -12724.3671875,
+            "z": 2071.1328125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 653141
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -8188.5676419470465,
+            "y": -11260.747693156009,
+            "z": 2550.609409945266
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.15066110102824026,
+            "w": 0.9885854705775106
+          },
+          "position": {
+            "x": -6486.7421875,
+            "y": -12279.5546875,
+            "z": 2388.9140625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 653932
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 14187.524218523,
+            "y": -6572.511099288868,
+            "z": 936.3604494860241
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7409513532050142,
+            "w": 0.6715587034531371
+          },
+          "position": {
+            "x": 14628.46875,
+            "y": -1503.3828125,
+            "z": 1116.8125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 654044
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -5863.003553387057,
+            "y": -12844.073955152036,
+            "z": 1979.9095937146146
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9407056616297844,
+            "w": 0.33922390566949945
+          },
+          "position": {
+            "x": -5482.265625,
+            "y": -12513.2109375,
+            "z": 1995.84375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 656292
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -5509.67358312964,
+            "y": -12689.176924640711,
+            "z": 2046.7908578119489
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.7728382505680575,
+            "w": 0.6346030558222236
+          },
+          "position": {
+            "x": -5508.265625,
+            "y": -12374.3828125,
+            "z": 2012.8046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 660713
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -5588.460563160533,
+            "y": -12487.78754175704,
+            "z": 1991.1887540491969
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.15043128024882946,
+            "w": 0.9886204680880819
+          },
+          "position": {
+            "x": -6047.71875,
+            "y": -12074.203125,
+            "z": 2392.1640625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 665057
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 10295.115634948133,
+            "y": 8609.579743819762,
+            "z": 1950.2715360443024
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.5361337886511687,
+            "w": 0.8441330230873234
+          },
+          "position": {
+            "x": 9494.484375,
+            "y": 10210.3046875,
+            "z": 2024.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": true,
+      "timestamp": 682870
+    },
+    {
+      "eliminated": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -802.3672514120121,
+            "y": -4485.573333349641,
+            "z": 1613.6220669863196
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7115300373603947,
+            "w": 0.7026556809233919
+          },
+          "position": {
+            "x": -758.0859375,
+            "y": -6275.1875,
+            "z": 1993.6953125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 684970
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4540.401281656463,
+            "y": -1165.813177996227,
+            "z": 1621.1499959669368
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.983570166773236,
+            "w": 0.18052625026202862
+          },
+          "position": {
+            "x": 4882.9140625,
+            "y": -958.765625,
+            "z": 1614.9609375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 686450
+    },
+    {
+      "eliminated": {
+        "id": "aaf8ed3e2ce04898b5040bf2571c7c7d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 10206.94420518999,
+            "y": 8149.762572755589,
+            "z": 1849.0267673891826
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.6436347721051248,
+            "w": 0.7653327904494778
+          },
+          "position": {
+            "x": 10151.1796875,
+            "y": 8572.2734375,
+            "z": 1973.3828125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 686606
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4675.342465057691,
+            "y": -457.5757891191431,
+            "z": 1613.0828018575874
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9191135419889713,
+            "w": 0.39399276253820614
+          },
+          "position": {
+            "x": 7288.3203125,
+            "y": -3037.4453125,
+            "z": 1593.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "06",
+      "knocked": true,
+      "timestamp": 687034
+    },
+    {
+      "eliminated": {
+        "id": "f25f0977f2ea4f549fce28b3f9760557",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -637.6819285613328,
+            "y": -7352.730272369024,
+            "z": 1972.4317754100834
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.45660484668330187,
+            "w": 0.8896696094535983
+          },
+          "position": {
+            "x": -1622.859375,
+            "y": -8780.765625,
+            "z": 2142.8203125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 687689
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4265.322072346804,
+            "y": -834.0266577917463,
+            "z": 1621.15099662612
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8975889433573074,
+            "w": 0.4408334025033857
+          },
+          "position": {
+            "x": 4404.828125,
+            "y": -882.7578125,
+            "z": 1621.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 690636
+    },
+    {
+      "eliminated": {
+        "id": "1d9cf12590e148cb81d48fdc6b2cf1b5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4388.880081798575,
+            "y": -981.7160650127067,
+            "z": 1596.1519960768037
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.02416741856253421,
+            "w": 0.9997079252861927
+          },
+          "position": {
+            "x": 4236.484375,
+            "y": -864.109375,
+            "z": 1621.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 692361
+    },
+    {
+      "eliminated": {
+        "id": "9a924d69eb1045a797ec15ff3c2a46a2",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 4417.125111308962,
+            "y": -718.5505672396883,
+            "z": 1596.1499984719762
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3a2d0f60c51846b38159b68986a353c4",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8392815320068666,
+            "w": 0.5436970756149117
+          },
+          "position": {
+            "x": 7305.03125,
+            "y": -2792.0234375,
+            "z": 1593.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "06",
+      "knocked": false,
+      "timestamp": 692487
+    },
+    {
+      "eliminated": {
+        "id": "1dd82ae703de4fd6a41eef741520757d",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 5747.350169304598,
+            "y": 1054.8581863832858,
+            "z": 1701.0713855727365
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9139733777424734,
+            "w": 0.40577415489162655
+          },
+          "position": {
+            "x": 6102.8671875,
+            "y": 905.5546875,
+            "z": 1742.6171875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 692503
+    },
+    {
+      "eliminated": {
+        "id": "76e7ecbe267d4255b1b601a70d1e08a5",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 3889.6469291366243,
+            "y": -1172.4762145479594,
+            "z": 1596.1500027879244
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "763be4687c344696882afd1fc4160819",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.006776435109755725,
+            "w": 0.999977039700014
+          },
+          "position": {
+            "x": 4235.3828125,
+            "y": -861.5859375,
+            "z": 1621.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 692545
+    },
+    {
+      "eliminated": {
+        "id": "f25f0977f2ea4f549fce28b3f9760557",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -507.0915624881112,
+            "y": -6747.993040583256,
+            "z": 1980.1500026318156
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.5004489662738395,
+            "w": 0.8657660377696996
+          },
+          "position": {
+            "x": -1619.7578125,
+            "y": -8787.734375,
+            "z": 2142.1015625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 693137
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1610.2216024451739,
+            "y": -8753.684233459497,
+            "z": 2166.293381252561
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.7958409579793378,
+            "w": 0.6055057139305375
+          },
+          "position": {
+            "x": -1372.609375,
+            "y": -9492.515625,
+            "z": 2060.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 694630
+    },
+    {
+      "eliminated": {
+        "id": "09d9ba31f7144149ae159f8be5c17cbc",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1493.5696239542451,
+            "y": -8611.331357014064,
+            "z": 2125.2506756030266
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.130238587537298,
+            "w": 0.991482682812105
+          },
+          "position": {
+            "x": -1707.171875,
+            "y": -8748.1484375,
+            "z": 2175.2109375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 697120
+    },
+    {
+      "eliminated": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1575.7882041857283,
+            "y": -8845.737745579792,
+            "z": 2161.420853782898
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.03303745825939393,
+            "w": 0.9994541141802155
+          },
+          "position": {
+            "x": -4601.4453125,
+            "y": -8620.2265625,
+            "z": 3864.0390625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 697601
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -7865.323816626873,
+            "y": -1232.3574083708127,
+            "z": 2949.1342223795327
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.4220597450911757,
+            "w": 0.906568018172697
+          },
+          "position": {
+            "x": -10087.34375,
+            "y": 1637.5,
+            "z": 2365.7265625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": true,
+      "timestamp": 701431
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 8447.669305081483,
+            "y": 7886.928316505072,
+            "z": 2337.857846668917
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "92ad069663fc4029a1d8f1ea936a33ab",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9350035867132972,
+            "w": 0.35463825630248874
+          },
+          "position": {
+            "x": 8696.890625,
+            "y": 8220.953125,
+            "z": 2256.9296875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 702978
+    },
+    {
+      "eliminated": {
+        "id": "d7f9ce75b53e4777b9e59a238a56d26e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 8915.398281376381,
+            "y": 5819.135481447178,
+            "z": 1737.8078279005363
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.8505975827197889,
+            "w": 0.5258172232546703
+          },
+          "position": {
+            "x": 10600.3359375,
+            "y": 9047.2890625,
+            "z": 1977.90625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 706707
+    },
+    {
+      "eliminated": {
+        "id": "2daf8468728d4d25ae3b5c35f1b2468a",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -562.1479425033866,
+            "y": -8547.45921234445,
+            "z": 1885.6878524992105
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.15786187733100368,
+            "w": 0.987461203129283
+          },
+          "position": {
+            "x": -1270.40625,
+            "y": -8781.15625,
+            "z": 2056.03125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 707112
+    },
+    {
+      "eliminated": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 10341.557378607573,
+            "y": 8869.336997991197,
+            "z": 1982.8106015423941
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6531728429537768,
+            "w": 0.7572088465064847
+          },
+          "position": {
+            "x": 8589.4375,
+            "y": -4658.28125,
+            "z": 2581.609375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": true,
+      "timestamp": 707721
+    },
+    {
+      "eliminated": {
+        "id": "568ead27775f43e4bf1c7b270faa8545",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 8987.987375086228,
+            "y": 7469.236624714384,
+            "z": 2079.826249796703
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "92ad069663fc4029a1d8f1ea936a33ab",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.33917868339679114,
+            "w": 0.9407219678147307
+          },
+          "position": {
+            "x": 8837.921875,
+            "y": 7622.8671875,
+            "z": 2219.2109375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 710340
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -599.9931120314012,
+            "y": -6717.458371825435,
+            "z": 1980.1499963474766
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8750667345566063,
+            "w": 0.4840022831272986
+          },
+          "position": {
+            "x": -355.4921875,
+            "y": -7068.5859375,
+            "z": 1997.4296875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 710742
+    },
+    {
+      "eliminated": {
+        "id": "50c6d6c4f86949f793ed68dcf6c89ce6",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 5653.979904009877,
+            "y": 763.8345220894944,
+            "z": 1688.3250109434223
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6241547305866965,
+            "w": 0.7813007566144093
+          },
+          "position": {
+            "x": 5287.859375,
+            "y": -1116.9296875,
+            "z": 1610.015625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 711203
+    },
+    {
+      "eliminated": {
+        "id": "b5ba1c8d529e4c52bf22f4e12817cd75",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -530.4730242795874,
+            "y": -6805.276071185745,
+            "z": 1980.1499963474766
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.8447009482095674,
+            "w": 0.5352385525108012
+          },
+          "position": {
+            "x": -443.671875,
+            "y": -6971.09375,
+            "z": 1996.890625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 711290
+    },
+    {
+      "eliminated": {
+        "id": "02df75441ec14c8ab547984104961074",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -7256.59164486011,
+            "y": -3201.682748792176,
+            "z": 1822.8399195982436
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.33355444166985454,
+            "w": 0.9427308388094194
+          },
+          "position": {
+            "x": -7504.265625,
+            "y": -3058.8515625,
+            "z": 1785.6796875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": false,
+      "timestamp": 712479
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 319.78073949087917,
+            "y": -8573.157034451557,
+            "z": 1503.5220920064044
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.012271538285719925,
+            "w": 0.9999247018391446
+          },
+          "position": {
+            "x": -5048.8046875,
+            "y": -8443.8828125,
+            "z": 3909.765625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 714861
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -2816.737370432385,
+            "y": -3288.5024626514573,
+            "z": 1611.2613591696072
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.16584501994989223,
+            "w": 0.9861518287555013
+          },
+          "position": {
+            "x": -3771.875,
+            "y": -3735.7109375,
+            "z": 2525.9296875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": true,
+      "timestamp": 727609
+    },
+    {
+      "eliminated": {
+        "id": "66bb35faaebf47f88858188c72edce51",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 8527.358631270115,
+            "y": -3928.1985950840644,
+            "z": 1286.9845080303178
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9532075496026058,
+            "w": 0.30231666738801527
+          },
+          "position": {
+            "x": 11173.3125,
+            "y": 9788.0703125,
+            "z": 2027.5859375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "01",
+      "knocked": false,
+      "timestamp": 730537
+    },
+    {
+      "eliminated": {
+        "id": "d7f9ce75b53e4777b9e59a238a56d26e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 8549.623005112533,
+            "y": 1896.6177408068854,
+            "z": 1472.296311236195
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "0027162bca1a4623b09bebc217baf3ec",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9451118640785453,
+            "w": 0.32674694241565194
+          },
+          "position": {
+            "x": 11068.9921875,
+            "y": 9686.640625,
+            "z": 2021.515625
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 730708
+    },
+    {
+      "eliminated": {
+        "id": "25a2b27bd90b4cb1add808d8b50a6a92",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -2321.5534246950197,
+            "y": -3345.8892574414863,
+            "z": 1585.3592881129714
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.014755920618518902,
+            "w": 0.9998911254765191
+          },
+          "position": {
+            "x": -2329.1015625,
+            "y": -3411.5390625,
+            "z": 1599.75
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 730987
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -1025.0175793771814,
+            "y": -6915.196206973742,
+            "z": 2231.2347773550246
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.2548656596045146,
+            "w": 0.9669764710448522
+          },
+          "position": {
+            "x": -5015.25,
+            "y": -4734.453125,
+            "z": 2671.9375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 731163
+    },
+    {
+      "eliminated": {
+        "id": "cf73e5ef4bba4473b781d30073a3d024",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 90.56860240266265,
+            "y": -4953.946429101761,
+            "z": 1437.0070955976648
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.6255899645739429,
+            "w": 0.7801520340448861
+          },
+          "position": {
+            "x": -360.40625,
+            "y": -6461.640625,
+            "z": 2486.2109375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "05",
+      "knocked": false,
+      "timestamp": 735724
+    },
+    {
+      "eliminated": {
+        "id": "11ab3d5a37ae4565afd360788a059b10",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": -353.40311881931046,
+            "y": -6967.202778278765,
+            "z": 1972.1849314645715
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "3def9412722b4a30bdc313fc78478aef",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.06313386697045484,
+            "w": 0.9980050675429242
+          },
+          "position": {
+            "x": -3886.8515625,
+            "y": -5033.078125,
+            "z": 2389.046875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 735872
+    },
+    {
+      "eliminated": {
+        "id": "9a24d3c010974e829b6cdc219bf75482",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 10333.074831392401,
+            "y": 9367.375730524258,
+            "z": 2052.1269905890417
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1df44e000c05449b935c9beba96cd556",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.010724786733980538,
+            "w": 0.99994248782093
+          },
+          "position": {
+            "x": -9714.765625,
+            "y": 8153.796875,
+            "z": 4697.1484375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "0d",
+      "knocked": true,
+      "timestamp": 745638
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 3974.4040384687346,
+            "y": -1749.8525448534042,
+            "z": 1560.7567978837385
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0.9939910481798375,
+            "w": 0.10946139108538493
+          },
+          "position": {
+            "x": 6471.5390625,
+            "y": -2559.828125,
+            "z": 1593.546875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": true,
+      "timestamp": 746337
+    },
+    {
+      "eliminated": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 791.941522797531,
+            "y": -4675.267826794467,
+            "z": 1221.3430551402676
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.06859717564287586,
+            "w": 0.9976444394140731
+          },
+          "position": {
+            "x": -1434.78125,
+            "y": -4412.5234375,
+            "z": 1539.71875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": true,
+      "timestamp": 751170
+    },
+    {
+      "eliminated": {
+        "id": "a969358bf378426c9ef8cf85d13685c7",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 610.5262782915617,
+            "y": -4718.626471746394,
+            "z": 1220.3006929530304
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "1a030fadc77d48b68ef082d9a7efbcb8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.038962817804401965,
+            "w": 0.9992406611166007
+          },
+          "position": {
+            "x": -1397.6953125,
+            "y": -4441.8671875,
+            "z": 1510.1796875
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "04",
+      "knocked": false,
+      "timestamp": 752293
+    },
+    {
+      "eliminated": {
+        "id": "25c8a2b23f6e4febbbb1e5bb553eb8df",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 730.448793541101,
+            "y": -4628.164647593767,
+            "z": 1227.328134541771
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "54acfa6c8f2146d49b02fbb0db4a61ea",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.005239960761542519,
+            "w": 0.9999862713113703
+          },
+          "position": {
+            "x": -534.3203125,
+            "y": -4599.59375,
+            "z": 1484.28125
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "03",
+      "knocked": false,
+      "timestamp": 752344
+    },
+    {
+      "eliminated": {
+        "id": "ea7f53cac0a74133bc2f529674d6a0e8",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": 0,
+            "w": 1
+          },
+          "position": {
+            "x": 3883.050566119305,
+            "y": -2433.482051730482,
+            "z": 1302.9633175553724
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "eliminator": {
+        "id": "b9e9e8bb21d94e529de5c59a2a932a7e",
+        "isBot": false,
+        "location": {
+          "rotation": {
+            "x": 0,
+            "y": 0,
+            "z": -0.9415440651830209,
+            "w": 0.3368898533922199
+          },
+          "position": {
+            "x": 4994,
+            "y": -1219.25,
+            "z": 1613.0859375
+          },
+          "scale": {
+            "x": 1,
+            "y": 1,
+            "z": 1
+          }
+        }
+      },
+      "gunType": "02",
+      "knocked": false,
+      "timestamp": 752480
+    }
+  ],
+  "additionGfps": [],
+  "safeZones": [],
+  "playerPositions": {}
+}


### PR DESCRIPTION
## Christmas Update!
As the comments indicate, in some places Epic Games added a few bytes of data, which caused the BinaryReader to crash when it tried to parse strings (it no longer had the correct string size to parse).
For now, I'm simply skipping this data as it is unclear and/or not useful.

Tests were conducted with the latest update (v33.11) and everything works without apparent issues.

I also added a warning for future file versions.